### PR TITLE
feat: option to automatically calculate response token count

### DIFF
--- a/haystack/nodes/prompt/invocation_layer/chatgpt.py
+++ b/haystack/nodes/prompt/invocation_layer/chatgpt.py
@@ -127,9 +127,20 @@ class ChatGPTInvocationLayer(OpenAIInvocationLayer):
             messages = prompt
 
         n_prompt_tokens = count_openai_tokens_messages(messages, self._tokenizer)
-        n_answer_tokens = self.max_length
-        if (n_prompt_tokens + n_answer_tokens) <= self.max_tokens_limit:
-            return prompt
+
+        # Where max_length is not set, use the maximum number of tokens for the response allowed by the model
+        if not hasattr(self, "max_length"):
+            # We have to adjust the reponse token length by 1, or OpenAI will complain:
+            # "This model's maximum context length is 4097 tokens. However, you requested 4097 tokens
+            # (1956 in the messages, 2141 in the completion)."
+            n_response_tokens = self.max_tokens_limit - (1 + n_prompt_tokens)
+            if n_response_tokens > 0:
+                self.max_length = n_response_tokens
+                return prompt
+        else:
+            n_answer_tokens = self.max_length
+            if (n_prompt_tokens + n_answer_tokens) <= self.max_tokens_limit:
+                return prompt
 
         # TODO: support truncation as in _ensure_token_limit methods for other invocation layers
         raise ValueError(

--- a/haystack/nodes/prompt/invocation_layer/open_ai.py
+++ b/haystack/nodes/prompt/invocation_layer/open_ai.py
@@ -56,11 +56,6 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
         self.api_key = api_key
         self.api_base = api_base
 
-        # 16 is the default length for answers from OpenAI shown in the docs
-        # here, https://platform.openai.com/docs/api-reference/completions/create.
-        # max_length must be set otherwise OpenAIInvocationLayer._ensure_token_limit will fail.
-        self.max_length = max_length or 16
-
         # Due to reflective construction of all invocation layers we might receive some
         # unknown kwargs, so we need to take only the relevant.
         # For more details refer to OpenAI documentation
@@ -134,7 +129,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
             "model": self.model_name_or_path,
             "prompt": prompt,
             "suffix": kwargs_with_defaults.get("suffix", None),
-            "max_tokens": kwargs_with_defaults.get("max_tokens", self.max_length),
+            "max_tokens": kwargs_with_defaults.get("max_tokens", self.max_length or 16),
             "temperature": kwargs_with_defaults.get("temperature", 0.7),
             "top_p": kwargs_with_defaults.get("top_p", 1),
             "n": kwargs_with_defaults.get("n", 1),
@@ -183,7 +178,7 @@ class OpenAIInvocationLayer(PromptModelInvocationLayer):
         :param prompt: Prompt text to be sent to the generative model.
         """
         n_prompt_tokens = len(self._tokenizer.encode(cast(str, prompt)))
-        n_answer_tokens = self.max_length
+        n_answer_tokens = self.max_length or 16
         if (n_prompt_tokens + n_answer_tokens) <= self.max_tokens_limit:
             return prompt
 


### PR DESCRIPTION
### Related Issues

This implements https://github.com/deepset-ai/haystack/issues/5047

### Proposed Changes:

Calculate the number of response tokens automatically based on the token length of the prompt and the maximum token length for the model.

When specifying `max_length=None` on `PromptNode` using ChatGPT models, the length of the response is automatically calculated.

### How did you test it?

Have yet to do this, can't get testing up and running locally. Will observe CI/CD.

### Notes for the reviewer

<!-- E.g. point out section where the reviewer  -->

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
